### PR TITLE
Fix the Lambda function of empty S3 bucket

### DIFF
--- a/templates/empty-bucket.yml
+++ b/templates/empty-bucket.yml
@@ -22,13 +22,6 @@ Resources:
     DependsOn:
       - S3CleanUpRole
     Properties:
-      Description: Empty S3 bucket
-      Handler: index.handler
-      Role: !GetAtt
-        - S3CleanUpRole
-        - Arn
-      Runtime: python2.7
-      Timeout: 240
       Code:
         ZipFile: !Join
           - |+
@@ -58,7 +51,7 @@ Resources:
             - '            print("bucket is already empty")'
             - ''
             - ''
-            - 'def delete_versionedobjects(bucket):'
+            - 'def delete_versioned_objects(bucket):'
             - '    print(''Collect data from %s'' % bucket)'
             - '    paginator = client.get_paginator(''list_object_versions'')'
             - '    result = paginator.paginate(Bucket=bucket)'
@@ -97,11 +90,11 @@ Resources:
             - '        dest_bucket = event[''ResourceProperties''][''DestBucket'']'
             - '        if event[''RequestType''] == ''Delete'':'
             - '            check_if_versioned = client.get_bucket_versioning(Bucket=dest_bucket)'
-            - '            print check_if_versioned'
+            - '            print(check_if_versioned)'
             - '            if ''Status'' in check_if_versioned:'
             - '                print check_if_versioned[''Status'']'
             - '                print("Delete a versioned Bucket")'
-            - '                delete_versionedobjects(dest_bucket)'
+            - '                delete_versioned_objects(dest_bucket)'
             - '            else:'
             - '                print("Delete a nonversioned Bucket")'
             - '                delete_nonversioned_objects(dest_bucket)'
@@ -114,6 +107,13 @@ Resources:
             - '        timer.cancel()'
             - '        cfnresponse.send(event, context, status, {}, None)'
             - ''
+      Description: Empty the S3 Bucket
+      Handler: index.handler
+      Role: !GetAtt
+        - S3CleanUpRole
+        - Arn
+      Runtime: python2.7
+      Timeout: 240
   S3CleanUpRole:
     Type: 'AWS::IAM::Role'
     Properties:


### PR DESCRIPTION
## Summary

Due to the error message found in CloudWatch
```
Syntax error in module 'index': Missing parentheses in call to 'print'. 
Did you mean print(check_if_versioned)? (index.py, line 65)
```

## Execution result 
View the whole task cast execution via `taskcat test run`
```
mongche@mongches-MacBook-Pro component-streaming-media-webapp % taskcat test run
 _            _             _   
| |_ __ _ ___| | _____ __ _| |_ 
| __/ _` / __| |/ / __/ _` | __|
| || (_| \__ \   < (_| (_| | |_ 
 \__\__,_|___/_|\_\___\__,_|\__|
                                


version 0.9.20
[INFO   ] : Linting passed for file: /Users/mongche/Documents/development/molpadia/component-streaming-media-webapp/templates/iam-roles.yml
[WARN   ] : ---
[WARN   ] : Linting detected issues in: /Users/mongche/Documents/development/molpadia/component-streaming-media-webapp/templates/streaming-media-master.yml
[WARN   ] :     line 36 [2001] [Check if Parameters are Used] Parameter S3BucketRegion not used.
[WARN   ] :     line 104 [3005] [Check obsolete DependsOn configuration for Resources] Obsolete DependsOn on resource (ArtifactBucket),
                                                                             dependency already enforced by a "Ref" at Resources/
                                                                             IAMRoleStack/Properties/Parameters/ArtifactBucket/Re
                                                                             f
[WARN   ] :     line 115 [3005] [Check obsolete DependsOn configuration for Resources] Obsolete DependsOn on resource (ArtifactBucket),
                                                                             dependency already enforced by a "Ref" at Resources/
                                                                             CodePipelineStack/Properties/Parameters/ArtifactBuck
                                                                             et/Ref
[WARN   ] :     line 116 [3005] [Check obsolete DependsOn configuration for Resources] Obsolete DependsOn on resource (IAMRoleStack),
                                                                             dependency already enforced by a "Fn:GetAtt" at Reso
                                                                             urces/CodePipelineStack/Properties/Parameters/CodePi
                                                                             pelineRoleArn/Fn::GetAtt
[WARN   ] :     line 116 [3005] [Check obsolete DependsOn configuration for Resources] Obsolete DependsOn on resource (IAMRoleStack),
                                                                             dependency already enforced by a "Fn:GetAtt" at Reso
                                                                             urces/CodePipelineStack/Properties/Parameters/CodeBu
                                                                             ildRoleArn/Fn::GetAtt
[WARN   ] :     line 139 [3005] [Check obsolete DependsOn configuration for Resources] Obsolete DependsOn on resource (ArtifactBucket),
                                                                             dependency already enforced by a "Ref" at Resources/
                                                                             EmptyBucketLambdaStack/Properties/Parameters/BucketN
                                                                             ame/Ref
[WARN   ] : ---
[WARN   ] : Linting detected issues in: /Users/mongche/Documents/development/molpadia/component-streaming-media-webapp/templates/empty-bucket.yml
[WARN   ] :     line 14 [3005] [Check obsolete DependsOn configuration for Resources] Obsolete DependsOn on resource
                                                                            (CleanUpS3BucketFunction), dependency already
                                                                            enforced by a "Fn:GetAtt" at Resources/CleanUpS3Bucke
                                                                            t/Properties/ServiceToken/Fn::GetAtt
[WARN   ] :     line 23 [3005] [Check obsolete DependsOn configuration for Resources] Obsolete DependsOn on resource (S3CleanUpRole),
                                                                            dependency already enforced by a "Fn:GetAtt" at Resou
                                                                            rces/CleanUpS3BucketFunction/Properties/Role/Fn::GetA
                                                                            tt
[WARN   ] :     line 143 [1020] [Sub isn't needed if it doesn't have a variable defined] Fn::Sub isn't needed because there are no
                                                                               variables at Resources/S3CleanUpRole/Properties/Po
                                                                               licies/0/PolicyDocument/Statement/0/Resource/1/Fn:
                                                                               :Sub
[WARN   ] : ---
[WARN   ] : Linting detected issues in: /Users/mongche/Documents/development/molpadia/component-streaming-media-webapp/templates/ci-pipeline.yml
[WARN   ] :     line 14 [2001] [Check if Parameters are Used] Parameter ReleaseBranch not used.
[WARN   ] :     line 104 [1020] [Sub isn't needed if it doesn't have a variable defined] Fn::Sub isn't needed because there are no
                                                                               variables at Resources/CodeBuild/Properties/Source
                                                                               /BuildSpec/Fn::Sub
[WARN   ] : ---
[WARN   ] : Linting detected issues in: /Users/mongche/Documents/development/molpadia/component-streaming-media-webapp/templates/media-storage.yml
[WARN   ] :     line 34 [3005] [Check obsolete DependsOn configuration for Resources] Obsolete DependsOn on resource
                                                                            (ProcessingFileMetadataExecutionRole), dependency
                                                                            already enforced by a "Fn:GetAtt" at Resources/Proces
                                                                            singFileMetadataLambdaFunction/Properties/Role/Fn::Ge
                                                                            tAtt
[WARN   ] :     line 37 [1020] [Sub isn't needed if it doesn't have a variable defined] Fn::Sub isn't needed because there are no variables
                                                                              at Resources/ProcessingFileMetadataLambdaFunction/P
                                                                              roperties/Code/ZipFile/Fn::Sub
[S3: -> ] s3://tcat-component-streaming-media-wedw3vb4pj/component-streaming-media-webapp/LICENSE
[S3: -> ] s3://tcat-component-streaming-media-wedw3vb4pj/component-streaming-media-webapp/ci/config.yml
[S3: -> ] s3://tcat-component-streaming-media-wedw3vb4pj/component-streaming-media-webapp/ci/taskcat.yml
[S3: -> ] s3://tcat-component-streaming-media-wedw3vb4pj/component-streaming-media-webapp/ci/taskcat-input-parameters.json
[S3: -> ] s3://tcat-component-streaming-media-wedw3vb4pj/component-streaming-media-webapp/templates/iam-roles.yml
[S3: -> ] s3://tcat-component-streaming-media-wedw3vb4pj/component-streaming-media-webapp/templates/empty-bucket.yml
[S3: -> ] s3://tcat-component-streaming-media-wedw3vb4pj/component-streaming-media-webapp/templates/ci-pipeline.yml
[S3: -> ] s3://tcat-component-streaming-media-wedw3vb4pj/component-streaming-media-webapp/templates/media-storage.yml
[S3: -> ] s3://tcat-component-streaming-media-wedw3vb4pj/component-streaming-media-webapp/templates/streaming-media-master.yml
[INFO   ] : ┏ stack Ⓜ tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-test-a4171faeef584714b12aa762a80e6905                                                                                           [INFO   ] : ┣ stack Ⓝ tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-MediaStorageStack-N3CRJZ65F4QW                                                                                                  [INFO   ] : ┣ stack Ⓝ tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-CodePipelineStack-9TC97TLA0C4G                                                                                                  [INFO   ] : ┣ stack Ⓝ tCaT-component-streaming-media-webapp-molpadia-streaming-taskca-EmptyBucketLambdaStack-Y3W4JAGTY3D5                                                                                                 [INFO   ] : ┣ stack Ⓝ tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-test-IAMRoleStack-I493NRG4UIMA                                                                                                  [INFO   ] : ┣ region: ap-northeast-1                                                                         [INFO   ] : ┗ status: CREATE_COMPLETE                                                                        
[INFO   ] : Reporting on arn:aws:cloudformation:ap-northeast-1:868556988516:stack/tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-test-a4171faeef584714b12aa762a80e6905/50ffd910-02db-11eb-be1e-0e7ed7880c96
[INFO   ] : Deleting stack: arn:aws:cloudformation:ap-northeast-1:868556988516:stack/tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-test-a4171faeef584714b12aa762a80e6905/50ffd910-02db-11eb-be1e-0e7ed7880c96
[INFO   ] : ┏ stack Ⓜ tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-test-a4171faeef584714b12aa762a80e6905                                                                                           [INFO   ] : ┣ stack Ⓝ tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-MediaStorageStack-N3CRJZ65F4QW                                                                                                  [INFO   ] : ┣ stack Ⓝ tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-CodePipelineStack-9TC97TLA0C4G                                                                                                  [INFO   ] : ┣ stack Ⓝ tCaT-component-streaming-media-webapp-molpadia-streaming-taskca-EmptyBucketLambdaStack-Y3W4JAGTY3D5                                                                                                 [INFO   ] : ┣ stack Ⓝ tCaT-component-streaming-media-webapp-molpadia-streaming-taskcat-ci-test-IAMRoleStack-I493NRG4UIMA                                                                                                  [INFO   ] : ┣ region: ap-northeast-1                                                                         [INFO   ] : ┗ status: DELETE_COMPLETE
```

https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252FtCaT-component-streaming-m-CleanUpS3BucketFunction-1W5CNVXFC6SC1/log-events/2020$252F09$252F29$252F$255B$2524LATEST$255D650ec75dfd5f49b0ad3d0728cff9f0f1