### PR TITLE
Fix a bug of undefined package directory during build phase

### DIFF
--- a/templates/ci-pipeline.yml
+++ b/templates/ci-pipeline.yml
@@ -134,7 +134,6 @@ Resources:
                 - echo Pre-build $PROJECTNAME phase
                 - echo Current Directory is $CODEBUILD_SRC_DIR
                 - ls -al
-                - cd $PROJECTNAME
                 - git config --global url."https://github.com/".insteadOf "git@github.com:"
                 - git init
                 - git remote add origin https://$GITHUBTOKEN@github.com/$GITHUBUSER/$PROJECTNAME.git
@@ -143,7 +142,6 @@ Resources:
                 - git submodule init
                 - git submodule update --recursive
                 - ls -lR
-                - cd -
                 - aws configure set default.region ap-northeast-1
             build:
               commands:


### PR DESCRIPTION
## Summary

There's an error occurred at the build phase,
`cannot switch $PROJECTNAME directory in the path`

https://ap-northeast-1.console.aws.amazon.com/codesuite/codebuild/868556988516/projects/CodeBuild-FS4bHwmb49yA/build/CodeBuild-FS4bHwmb49yA%3A7019b0bc-dbb7-4bd2-bdb6-486ca320f27a/?region=ap-northeast-1