### PR TITLE
Upgrade awscli version to fix import package error in build phase

### DIFF
--- a/templates/ci-pipeline.yml
+++ b/templates/ci-pipeline.yml
@@ -127,6 +127,7 @@ Resources:
                 - apt-get update -y
                 - sudo apt-get install zip gzip tar -y
                 - pip3 install --upgrade pip
+                - pip3 install --upgrade awscli
                 - pip3 install taskcat==0.9.13
                 - ln -s /usr/local/bin/pip /usr/bin/pip
             pre_build:
@@ -142,7 +143,7 @@ Resources:
                 - git submodule init
                 - git submodule update --recursive
                 - ls -lR
-                - aws configure set default.region ap-northeast-1
+                - aws configure set default.region $AWS_REGION
             build:
               commands:
                 - echo Build $PROJECTNAME phase


### PR DESCRIPTION
## Summary
```
ImportError: cannot import name 'docevents
```

https://ap-northeast-1.console.aws.amazon.com/codesuite/codebuild/868556988516/projects/CodeBuild-8FSRDp1nILax/build/CodeBuild-8FSRDp1nILax%3A2f1f47de-ec03-4c94-9d0d-cad538c1f399/?region=ap-northeast-1
