### PR TITLE
Add addition option to resolve pip dependencies conflict in build phase

### DIFF
--- a/templates/ci-pipeline.yml
+++ b/templates/ci-pipeline.yml
@@ -127,7 +127,7 @@ Resources:
                 - apt-get update -y
                 - sudo apt-get install zip gzip tar -y
                 - pip3 install --upgrade pip
-                - pip3 install --upgrade awscli
+                - pip3 install --upgrade awscli --use-feature=2020-resolver
                 - pip3 install taskcat==0.9.13
                 - ln -s /usr/local/bin/pip /usr/bin/pip
             pre_build:
@@ -147,7 +147,6 @@ Resources:
             build:
               commands:
                 - echo Build $PROJECTNAME phase
-                - cd $PROJECTNAME
                 - taskcat -test run -l
                 - |
                   if $(grep -q "CREATE_FAILED" taskcat_outputs/index.html); then


### PR DESCRIPTION
## Summary

There's an error message in build phase
```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.
```

Add `--use-feature=2020-resolver` option to resolve the issue

https://ap-northeast-1.console.aws.amazon.com/codesuite/codebuild/868556988516/projects/CodeBuild-8FSRDp1nILax/build/CodeBuild-8FSRDp1nILax%3Aec8c7b36-9157-4fc0-910b-fd4c4f969fa4/?region=ap-northeast-1

https://github.com/nikukyugamer/dotfiles/blob/f6b7707c83bbfd74853e515ac1f7eb16dd3da542/install_and_upgrade_packages_of_pip.sh#L4