### PR TITLE
Change the process to upgrade awscli version in build phase

### DIFF
--- a/templates/ci-pipeline.yml
+++ b/templates/ci-pipeline.yml
@@ -127,7 +127,7 @@ Resources:
                 - apt-get update -y
                 - sudo apt-get install zip gzip tar -y
                 - pip3 install --upgrade pip
-                - pip3 install --user awscli --use-feature=2020-resolver
+                - pip3 install --upgrade --user awscli
                 - pip3 install taskcat==0.9.13
                 - ln -s /usr/local/bin/pip /usr/bin/pip
             pre_build:


### PR DESCRIPTION
## Summary

there's still an error occur `ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.`

https://ap-northeast-1.console.aws.amazon.com/codesuite/codebuild/868556988516/projects/CodeBuild-8FSRDp1nILax/build/CodeBuild-8FSRDp1nILax%3Aaceee9d9-2a99-4708-adc7-805668ad8342/?region=ap-northeast-1

https://github.com/pypa/pip/issues/8686