### PR TITLE
Fix python requests package module not found error

### DIFF
--- a/templates/ci-pipeline.yml
+++ b/templates/ci-pipeline.yml
@@ -171,9 +171,9 @@ Resources:
 
           - - import json
             - import logging
-            - import requests
             - import os
             - import boto3
+            - from botocore.vendored import requests
             - ''
             - 'region = os.envion[''AWS_REGION'']'
             - 'merge_endpoint = ''https://api.github.com/repos/{owner}/{repo}/merges'''


### PR DESCRIPTION
## Summary

We get the following error that cannot pack the python-requests module in AWS Lambda Function.
According to the [StackOverflow](https://stackoverflow.com/questions/40741282/cannot-use-requests-module-on-aws-lambda), we can pack requests package from `botocore.vendored` module

Another way is zipping to the lambda function and deploy to S3 Bucket before deploying the environment.

```
Unable to import module 'index': No module named 'requests'
```

https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fstreaming-media-webapp-prod-CodePip-GitMergeLambda-O4BPQSPND21B/log-events/2020$252F10$252F02$252F$255B$2524LATEST$255D88b8c2196cae460ca5745b51ffd941b3

## Resource
https://aws.amazon.com/tw/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/